### PR TITLE
chore(rc): Update rc branch to2 27 2

### DIFF
--- a/resources/patch-spinnaker-version.yml
+++ b/resources/patch-spinnaker-version.yml
@@ -5,4 +5,4 @@ metadata:
 spec:
   spinnakerConfig:
     config:
-      version: 2.27.1
+      version: 2.27.2


### PR DESCRIPTION
rc branch is used by our Managed spinnaker so we need it to point to the latest LTS version